### PR TITLE
Solve the problem of Object type <class 'str'> cannot be passed to C …

### DIFF
--- a/alipay/aop/api/util/EncryptUtils.py
+++ b/alipay/aop/api/util/EncryptUtils.py
@@ -30,6 +30,8 @@ def aes_encrypt_content(content, encrypt_key, charset):
         length = len(bytes(content))
     padded_content = pad(content, length)
     iv = '\0' * BLOCK_SIZE
+    if PYTHON_VERSION_3:
+        iv = bytes(iv, encoding="utf8")
     cryptor = AES.new(base64.b64decode(encrypt_key), AES.MODE_CBC, iv)
     encrypted_content = cryptor.encrypt(padded_content)
     encrypted_content = base64.b64encode(encrypted_content)
@@ -47,6 +49,8 @@ def decrypt_content(encrypted_content, encrypt_type, encrypt_key, charset):
 def aes_decrypt_content(encrypted_content, encrypt_key, charset):
     encrypted_content = base64.b64decode(encrypted_content)
     iv = '\0' * BLOCK_SIZE
+    if PYTHON_VERSION_3:
+        iv = bytes(iv, encoding="utf8")
     cryptor = AES.new(base64.b64decode(encrypt_key), AES.MODE_CBC, iv)
     content = unpad(cryptor.decrypt(encrypted_content))
     if PYTHON_VERSION_3:


### PR DESCRIPTION
我的环境python3.8.6 + pycryptodome3.14.1 线上会导致
TypeError: Object type <class 'str'> cannot be passed to C code
我试着将 iv 转成字节，发现可以了！